### PR TITLE
Admin Settings: Fix "noproxy" option.

### DIFF
--- a/twofactor_privacyidea/js/settings-admin.js
+++ b/twofactor_privacyidea/js/settings-admin.js
@@ -28,8 +28,13 @@ $(document).ready(function () {
             function(result) {
                 $("#piSettings #checkssl").prop('checked', result === "1");
             }
-            );    
-    
+            );
+    $.get(OC.generateUrl(BASE_URL + 'noproxy')).done(
+        function(result) {
+            $("#piSettings #noproxy").prop('checked', result === "1");
+        }
+    );
+
     $.get(OC.generateUrl(BASE_URL + 'realm')).done(
             function(result) {
                 $("#piSettings #pirealm").val(result);

--- a/twofactor_privacyidea/lib/Controller/SettingsController.php
+++ b/twofactor_privacyidea/lib/Controller/SettingsController.php
@@ -44,8 +44,10 @@ class SettingsController extends Controller {
             return $this->config->getAppValue('twofactor_privacyidea', 'checkssl');
         }
 
-        /*
+        /**
          * enable/disable no Proxy
+         *
+         * @param bool $noproxy
          */
         public function setNoProxy($noproxy) {
             $value = $noproxy ? '1' : '0';


### PR DESCRIPTION
 * The admin panel always displayed "noproxy" as being disabled.
 * Given the option was enabled once, it was impossible to disable
   it again due to a missing type cast in SettingsController.