### PR TITLE
Do not check checkbox if piactive is unset

### DIFF
--- a/twofactor_privacyidea/js/settings-admin.js
+++ b/twofactor_privacyidea/js/settings-admin.js
@@ -61,7 +61,7 @@ $(document).ready(function () {
 
     /* Activate privacyIDEA */
     getValue("piactive", function(piactive) {
-        $("#piSettings #piactive").prop('checked', piactive !== "0");
+        $("#piSettings #piactive").prop('checked', piactive === "1");
     });
     $('#piSettings #piactive').change(function() {
        setValue("piactive", $(this).is(":checked") ? "1" : "0");


### PR DESCRIPTION
Closes #15 

I *think* this should be the way to go, as [the provider](https://github.com/NetKnights-GmbH/privacyidea-owncloud-app/blob/master/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php#L327) currently also checks for ``piactive === "1"``. So with this change, frontend and backend would be consistent.