### PR TITLE
Fix error handling during login

### DIFF
--- a/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
+++ b/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
@@ -234,7 +234,8 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
             // NOTE: Here, we check for `!== '0'` instead of `=== '1'` in order to verify certificates
             // by default just after app installation.
             'verify' => $checkssl !== '0',
-            'debug' => false];
+            'debug' => false,
+            'exceptions' => false];
         if ($noproxy === "1") {
             $options["proxy"] = ["https" => "", "http" => ""];
         }

--- a/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
+++ b/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
@@ -302,7 +302,7 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
                 ["message", $e->getMessage()]);
             $error_message = $this->trans->t("Failed to authenticate.") . " " . $e->getMessage();
         }
-        if (class_exists('TwoFactorException')) {
+        if (class_exists('OCP\Authentication\TwoFactorAuth\TwoFactorException')) {
             // This is the behaviour for OC >= 9.2
             throw new TwoFactorException($error_message);
         } else {


### PR DESCRIPTION
Fixes #18 

* According to the 2FA API for ownCloud >= 9.2, ``TwoFactorException`` should be thrown if 2FA fails, which displays an error message to the user. Our code didn't do that until now (see #18). dad9e65 fixes this. But the question is whether this is desired behavior. e.g. if privacyIDEA cannot resolve the user, it returns a HTTP 400, and the login form then shows ``Failed to authenticate. Wrong HTTP return code.``. Do we want the user to know that?
* By default, the HTTP client throws an exception if the return code is not 200. However, our code explicitly checks the HTTP status code, so there is no need to throw an exception. cc2da96 fixes this by [passing exceptions=false](http://docs.guzzlephp.org/en/5.3/clients.html#exceptions).