### PR TITLE
Added radiobuttons either include or exclude

### DIFF
--- a/twofactor_privacyidea/js/settings-admin.js
+++ b/twofactor_privacyidea/js/settings-admin.js
@@ -120,7 +120,25 @@ $(document).ready(function () {
         displayServerCredentials(checked);
     });
     
-    /* exclude owncloud user groups */
+    /* in or exclude owncloud user groups */
+    radioinclude = document.getElementById('piinclude');
+    radioexclude = document.getElementById('piexclude');
+    getValue("piexclude", function (piexclude) {
+        $("#piSettings #piinclude").prop('checked', piexclude ==="0");
+        $("#piSettings #piexclude").prop('checked', piexclude ==="1");
+    })
+
+    $("#piSettings #piinclude").change(function () {
+        if(radioinclude.checked){
+            setValue("piexclude", "0");
+        }
+    })
+    $("#piSettings #piexclude").change(function () {
+        if(radioexclude.checked){
+            setValue("piexclude", "1");
+        }
+    })
+
     OC.Settings.setupGroupsSelect($('#piSettings #piexcludegroups'));
     getValue("piexcludegroups", function (excludegroups) {
        $("#piSettings #piexcludegroups").val(excludegroups);

--- a/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
+++ b/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
@@ -341,6 +341,7 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
     {        
         $piactive = $this->getAppValue('piactive');
         $piexcludegroups = $this->getAppValue('piexcludegroups');
+        $piexclude= $this->getAppValue('piexclude');
         if ($piactive === "1") {
             // 2FA is basically enabled
             if ($piexcludegroups) {
@@ -349,7 +350,8 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
                 $piexcludegroupsCSV = str_replace("|", ",", $piexcludegroups);
                 $groups = explode(",", $piexcludegroupsCSV);
                 foreach($groups as $group) {
-                    if ($this->groupManager->isInGroup($user->getUID(), trim($group))) {
+                    if (($this->groupManager->isInGroup($user->getUID(), trim($group)) && $piexclude !== "0")
+                    || (!($this->groupManager->isInGroup($user->getUID(), trim($group))) && $piexclude === "0")) {
                         // The user is a group, that is allowed to pass with 1FA
                         return false;
                     };

--- a/twofactor_privacyidea/templates/settings-admin.php
+++ b/twofactor_privacyidea/templates/settings-admin.php
@@ -34,12 +34,14 @@ script('twofactor_privacyidea', 'settings-admin');
             </em>
         </p>
         <p>
-            <label for="piexcludegroups"><?php p($l->t('Exclude these groups from two factor authentication')); ?></label>
-            <input type="text" id="piexcludegroups" width="300px"/>
+            <input type="radio" name="inexclude" id="piinclude"><?php p($l->t('Include or ')); ?>
+            <input type="radio" name="inexclude" id="piexclude"><?php p($l->t('Exclude')); ?>
+            <label for="piexcludegroups"><?php p($l->t(' these groups from two factor authentication')); ?></label>
+            <input type="text" id="piexcludegroups" width="300px"   />
             <em>
                 <?php p($l->t('
-                    Users in the following groups will not need to do two factor authentication.
-                    Please enter a comma separated list of group names.
+                    If Include is selected, just the groups in this field need to do 2FA.
+                    If you select Exclude, these groups can use 1FA (others need 2FA).
                 ')); ?>
             </em>
         <p>

--- a/twofactor_privacyidea/templates/settings-admin.php
+++ b/twofactor_privacyidea/templates/settings-admin.php
@@ -41,7 +41,7 @@ script('twofactor_privacyidea', 'settings-admin');
             <em>
                 <?php p($l->t('
                     If Include is selected, just the groups in this field need to do 2FA.
-                    If you select Exclude, these groups can use 1FA (others need 2FA).
+                    If you select Exclude, these groups can use 1FA (all others need 2FA).
                 ')); ?>
             </em>
         <p>


### PR DESCRIPTION
Fixes #27
The administrator can choose between in or exlude. If Include is selected, all groups are excluded except these in the settings.
In this way, the administrator is able to activate privacyIDEA gradually.
But there is the possibility to exclude groups as well (the others are included then).