### PR TITLE
Ignore clients with specified ips

### DIFF
--- a/twofactor_privacyidea/js/settings-admin.js
+++ b/twofactor_privacyidea/js/settings-admin.js
@@ -154,7 +154,7 @@ $(document).ready(function () {
     });
 
     $("#piSettings #piexcludegroups").change(function () {
-       console.log("pi: Saving Excluse groups");
+       console.log("pi: Saving Exclude groups");
        var value = $("#piSettings #piexcludegroups").val();
        setValue("piexcludegroups", value);
     });

--- a/twofactor_privacyidea/js/settings-admin.js
+++ b/twofactor_privacyidea/js/settings-admin.js
@@ -159,6 +159,16 @@ $(document).ready(function () {
        setValue("piexcludegroups", value);
     });
 
+    getValue("piexcludeips", function (excludeips) {
+        $("#piSettings #piexcludeips").val(excludeips);
+    });
+
+    $("#piSettings #piexcludeips").change(function () {
+        console.log("pi: Saving excluded ips");
+        var value = $("#piSettings #piexcludeips").val();
+        setValue("piexcludeips", value);
+    });
+
     /* privacyIDEA service account username */
     getValue("serviceaccount_user", function (user) {
         $("#piSettings #piserviceaccount_user").val(user);

--- a/twofactor_privacyidea/templates/settings-admin.php
+++ b/twofactor_privacyidea/templates/settings-admin.php
@@ -82,12 +82,29 @@ script('twofactor_privacyidea', 'settings-admin');
                 </td>
                 <td>
                     <em>
-		                <?php p($l->t('
+				        <?php p($l->t('
 		                    If include is selected, just the groups in this field need to do 2FA.
 		                ')); ?>
                         <br>
-		                <?php p($l->t('
+				        <?php p($l->t('
 		                    If you select exclude, these groups can use 1FA (all others need 2FA).
+		                ')); ?>
+                    </em>
+                </td>
+            </tr>
+            <tr>
+                <td>
+	                <?php p($l->t('
+		                    Exclude ip addresses
+		                ')); ?>
+                </td>
+                <td>
+                    <input type="text" id="piexcludeips" width="300px"/>
+                </td>
+                <td>
+                    <em>
+				        <?php p($l->t('
+		                    You can either add single ips like 10.0.1.12,10.0.1.13, a range like 10.0.1.12-10.0.1.113 or comining it like 10.0.1.12-10.0.1.113,192.168.0.15
 		                ')); ?>
                     </em>
                 </td>

--- a/twofactor_privacyidea/templates/settings-admin.php
+++ b/twofactor_privacyidea/templates/settings-admin.php
@@ -104,7 +104,7 @@ script('twofactor_privacyidea', 'settings-admin');
                 <td>
                     <em>
 				        <?php p($l->t('
-		                    You can either add single ips like 10.0.1.12,10.0.1.13, a range like 10.0.1.12-10.0.1.113 or comining it like 10.0.1.12-10.0.1.113,192.168.0.15
+		                    You can either add single IPs like 10.0.1.12,10.0.1.13, a range like 10.0.1.12-10.0.1.113 or combinations like 10.0.1.12-10.0.1.113,192.168.0.15
 		                ')); ?>
                     </em>
                 </td>


### PR DESCRIPTION
If users in a local area network should not do 2fa, their ip addresses can be excluded.
The administrator can either exclude single ips or ranges.
closes #44