### PR TITLE
Fixed trigger challenge

### DIFF
--- a/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
+++ b/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
@@ -27,6 +27,7 @@ use OCP\Http\Client\IClientService;
 use OCP\ILogger;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\ISession;
 use Exception;
 // For OC < 9.2 the TwoFactorException does not exist. So we need to handle this in the method verifyChallenge
 use OCP\Authentication\TwoFactorAuth\TwoFactorException;
@@ -50,12 +51,14 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
     private $config;
     private $logger;
     private $trans;
+    private $session;
 
     public function __construct(IClientService $httpClientService,
                                 IConfig $config,
                                 ILogger $logger, IRequest $request,
                                 IGroupManager $groupManager,
-                                IL10N $trans)
+                                IL10N $trans,
+                                ISession $session)
     {
         $this->httpClientService = $httpClientService;
         $this->config = $config;
@@ -64,9 +67,9 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
         $this->request = $request;
         $this->hideOTPField = null;
         $this->detail = array();
-        $this->transactionId = null;
         $this->u2fSignRequest = null;
         $this->groupManager = $groupManager;
+        $this->session = $session;
     }
 
     /**
@@ -176,9 +179,8 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
                 if ($body->result->status === true) {
                     $detail = $body->detail;
                     $this->detail = $detail;
-                    if (property_exists($detail, "transaction_ids")) {
-                        // TODO: What should we do, if there was more than one transaction ID?
-                        $this->transactionId = $detail->transaction_ids[0];
+                    if (property_exists($detail, "transaction_id")) {
+                        $this->session->set("pi_transaction_id", $detail->transaction_id);
                     }
 
                     if (property_exists($detail, "multi_challenge")) {
@@ -221,20 +223,27 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
      */
     public function getTemplate(IUser $user)
     {
-        $messages = [];
-        if ($this->getAppValue('triggerchallenges', '') === '1') {
-            try {
-                $messages = $this->triggerChallenges($user->getUID());
-            } catch (TriggerChallengesException $e) {
-                $messages = [$e->getMessage()];
-            }
-        }
+
+    	$transactionId = $this->session->get("pi_transaction_id");
+
+    	if (!$transactionId) {
+			$messages = [];
+			if ($this->getAppValue('triggerchallenges', '') === '1') {
+				try {
+					$messages = $this->triggerChallenges($user->getUID());
+					$this->session->set("pi_message", $messages);
+				} catch (TriggerChallengesException $e) {
+					$messages = [$e->getMessage()];
+				}
+			}
+		} else {
+    		$messages = $this->session->get("pi_message");
+		}
         $template = new Template('twofactor_privacyidea', 'challenge');
         $template->assign("messages", array_unique($messages));
         $template->assign("hideOTPField", $this->hideOTPField);
         $template->assign("u2fSignRequest", $this->u2fSignRequest);
         $template->assign("detail", $this->detail);
-        $template->assign("transactionId", $this->transactionId);
         return $template;
     }
 
@@ -296,7 +305,7 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
             'pass' => $password,
             'realm' => $realm];
         // The verifyChallenge is called with additional parameters in case of challenge response:
-        $transaction_id = $this->request->getParam("transaction_id");
+        $transaction_id = $this->session->get("pi_transaction_id");
         $signatureData = $this->request->getParam("signatureData");
         $clientData = $this->request->getParam("clientData");
         $this->log("debug", "transaction_id: " . $transaction_id);

--- a/twofactor_privacyidea/templates/challenge.php
+++ b/twofactor_privacyidea/templates/challenge.php
@@ -20,7 +20,6 @@ if ($_["u2fSignRequest"]) {
 
 <form method="POST" id="piLoginForm" name="piLoginForm">
     <input type="hidden" name="redirect_url" value="<?php p($_['redirect_url']); ?>">
-    <input type="hidden" name="transaction_id" value="<?php p($_['transactionId']); ?>">
 
     <!-- only necessary for U2F. These hidden parameters are used in the script u2f.js -->
     <?php if ($u2fSignRequest): ?>


### PR DESCRIPTION
In #54 @cornelinux mentioned a bug with the trigger challenge.
The problem seems to be, that a new challenge is triggered after a
reload (even if a user enters a wrong otp value).
This is fixed now, because we save the transaction id in the session.

closes #54