### PR TITLE
Update TwoFactorPrivacyIDEAProvider.php

### DIFF
--- a/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
+++ b/twofactor_privacyidea/lib/Provider/TwoFactorPrivacyIDEAProvider.php
@@ -481,6 +481,7 @@ class TwoFactorPrivacyIDEAProvider implements IProvider
      * @param string $username user for which privacyIDEA should trigger challenges
      * @return string
      * @throws AdminAuthException
+     * @throws ProcessPIResponseException
      * @throws Exception
      */
     private function triggerChallenge(string $username): string


### PR DESCRIPTION
send the request parameters using `form_params` option instead of `body`. This option sends a "application/x-www-form-urlencoded" request, which is required by the new guzzle (HTTP-Client) version which OC-v10.11 use.

closing #93 